### PR TITLE
Output something if not RHEL

### DIFF
--- a/image-scanner.py
+++ b/image-scanner.py
@@ -251,6 +251,9 @@ class Worker(object):
                           .format(image, t))
 
             timeit.Timer(f.report_results).timeit(number=1)
+        else:
+            # This is not a RHEL image or container
+            f._report_not_rhel(image)
 
         # t = timeit.Timer(f.clean_up_chroot).timeit(number=1)
         start = time.time()

--- a/reporter.py
+++ b/reporter.py
@@ -24,7 +24,7 @@ from applicationconfiguration import ApplicationConfiguration
 class Reporter(object):
     def __init__(self):
         self.output = collections.namedtuple('Summary', 'iid, cid, os, sevs,'
-                                             'log')
+                                             'log, msg',)
         self.list_of_outputs = []
         self.ac = ApplicationConfiguration()
         self.report_dir = os.path.join(self.ac.reportdir, "openscap_reports")
@@ -36,26 +36,32 @@ class Reporter(object):
         print "Summary:"
         for image in self.list_of_outputs:
             short_cid_list = []
-            for cid in image.cid:
-                short_cid_list.append(cid[:12])
             print "{0}Image: {1}".format(" " * 5, image.iid)
-            print "{0}OS: {1}".format(" " * 5, image.os.rstrip())
-            print "{0}Containers affected " \
-                  "({1}): {2}".format(" " * 5, len(short_cid_list),
-                                      ', '.join(short_cid_list))
-            print "{0}Results: Critical({1}) Important({2}) Moderate({3}) " \
-                  "Low({4})".format(" " * 5, image.sevs['Critical'],
-                                    image.sevs['Important'],
-                                    image.sevs['Moderate'],  image.sevs['Low'])
-            print ""
+            if image.msg is None:
+                for cid in image.cid:
+                    short_cid_list.append(cid[:12])
+                print "{0}OS: {1}".format(" " * 5, image.os.rstrip())
+                print "{0}Containers affected " \
+                      "({1}): {2}".format(" " * 5, len(short_cid_list),
+                                          ', '.join(short_cid_list))
+                print "{0}Results: Critical({1}) Important({2}) Moderate({3}) " \
+                      "Low({4})".format(" " * 5, image.sevs['Critical'],
+                                        image.sevs['Important'],
+                                        image.sevs['Moderate'],  image.sevs['Low'])
+                print ""
+            else:
+                print "{0}Results: {1}".format(" " * 5, image.msg)
+                print ""
+
 
         report_files = []
         for image in self.list_of_outputs:
-            short_image = image.iid[:12] + ".scap"
-            out = open(os.path.join(self.report_dir, short_image), 'wb')
-            report_files.append(short_image)
-            out.write(image.log)
-            out.close
+            if image.msg is None:
+                short_image = image.iid[:12] + ".scap"
+                out = open(os.path.join(self.report_dir, short_image), 'wb')
+                report_files.append(short_image)
+                out.write(image.log)
+                out.close
 
         for report in report_files:
             print "Wrote CVE Summary report: {0}".format(

--- a/scan.py
+++ b/scan.py
@@ -164,8 +164,15 @@ class Scan(object):
         self.output.list_of_outputs.append(
             self.output.output(iid=self.image_name, cid=self.con_uuids,
                                os=self.os_release, sevs=sev_dict,
-                               log=sum_log.getvalue()))
+                               log=sum_log.getvalue(), msg=None))
         sum_log.close()
+
+    def _report_not_rhel(self, image):
+        msg = "{0} is not based on RHEL".format(image)
+        self.output.list_of_outputs.append(
+            self.output.output(iid=image, cid=None,
+                               os=None, sevs=None,
+                               log=None, msg=msg))
 
     def _return_xml_values(self, cve):
         cve_string = ("{http://oval.mitre.org/XMLSchema/oval-definitions-5}"


### PR DESCRIPTION
scan.py, reporter.py, image-scanner.py

This commit is a fix for:
    issue https://github.com/baude/image-scanner/issues/12

Which is basically that if an image isnt RHEL, nothing was
being output to the summary.  If that was the only image
that needed to be scanned, it makes it look like it failed.
Now users will know we inspected the image and didn't scan
it because it isnt rhel.
