### PR TITLE
* Allow broader inputs (container names, ids, image names)

### DIFF
--- a/applicationconfiguration.py
+++ b/applicationconfiguration.py
@@ -16,8 +16,10 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
+''' Class to handle references '''
 
 class Singleton(object):
+    ''' Singleton class to pass references'''
     _instance = None
 
     def __new__(cls, *args, **kwargs):
@@ -36,13 +38,18 @@ class Singleton(object):
 
 
 class ApplicationConfiguration(Singleton):
+    '''Application Configuration'''
     def _singleton_init(self, parserargs=None):
+        ''' Init for Application Configuration '''
         super(ApplicationConfiguration, self)._singleton_init()
         self.workdir = parserargs.workdir
         self.logfile = parserargs.logfile
         self.number = parserargs.number
         self.reportdir = parserargs.reportdir
         self.nocache = parserargs.nocache
+        self.cons = None
+        self.images = None
 
     def __init__(self, parserargs=None):
+        ''' init '''
         pass

--- a/reporter.py
+++ b/reporter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+# !/usr/bin/env python
 # Copyright (C) 2015 Brent Baude <bbaude@redhat.com>
 #
 # This library is free software; you can redistribute it and/or
@@ -15,6 +15,7 @@
 # License along with this library; if not, write to the
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
+'''Reporter Class'''
 
 import collections
 import os
@@ -22,37 +23,44 @@ from applicationconfiguration import ApplicationConfiguration
 
 
 class Reporter(object):
+    ''' Does stdout reporting '''
     def __init__(self):
         self.output = collections.namedtuple('Summary', 'iid, cid, os, sevs,'
                                              'log, msg',)
         self.list_of_outputs = []
-        self.ac = ApplicationConfiguration()
-        self.report_dir = os.path.join(self.ac.reportdir, "openscap_reports")
+        self.appc = ApplicationConfiguration()
+        self.report_dir = os.path.join(self.appc.reportdir, "openscap_reports")
 
         if not os.path.exists(self.report_dir):
             os.mkdir(self.report_dir)
 
     def report_summary(self):
+        '''
+        This function is the primary function to output results
+        to stdout when running the image-scanner
+        '''
         print "Summary:"
         for image in self.list_of_outputs:
             short_cid_list = []
-            print "{0}Image: {1}".format(" " * 5, image.iid)
+            dtype = self._get_dtype(image.iid)
+            print "{0}{1}: {2}".format(" " * 5, dtype, image.iid)
             if image.msg is None:
                 for cid in image.cid:
                     short_cid_list.append(cid[:12])
                 print "{0}OS: {1}".format(" " * 5, image.os.rstrip())
-                print "{0}Containers affected " \
-                      "({1}): {2}".format(" " * 5, len(short_cid_list),
-                                          ', '.join(short_cid_list))
-                print "{0}Results: Critical({1}) Important({2}) Moderate({3}) " \
-                      "Low({4})".format(" " * 5, image.sevs['Critical'],
-                                        image.sevs['Important'],
-                                        image.sevs['Moderate'],  image.sevs['Low'])
+                if dtype is not "Container":
+                    print "{0}Containers affected " \
+                          "({1}): {2}".format(" " * 5, len(short_cid_list),
+                                              ', '.join(short_cid_list))
+                print "{0}Results: Critical({1}) Important({2}) Moderate({3})"\
+                      " Low({4})".format(" " * 5, image.sevs['Critical'],
+                                         image.sevs['Important'],
+                                         image.sevs['Moderate'],
+                                         image.sevs['Low'])
                 print ""
             else:
                 print "{0}Results: {1}".format(" " * 5, image.msg)
                 print ""
-
 
         report_files = []
         for image in self.list_of_outputs:
@@ -66,3 +74,15 @@ class Reporter(object):
         for report in report_files:
             print "Wrote CVE Summary report: {0}".format(
                 os.path.join(self.report_dir, report))
+
+    def _get_dtype(self, iid):
+        ''' Returns whether the given id is an image or container '''
+        # Images
+        for image in self.appc.images:
+            if image['Id'].startswith(iid):
+                return "Image"
+        # Containers
+        for con in self.appc.cons:
+            if con['Id'].startswith(iid):
+                return "Container"
+        return None

--- a/scan.py
+++ b/scan.py
@@ -168,7 +168,7 @@ class Scan(object):
         sum_log.close()
 
     def _report_not_rhel(self, image):
-        msg = "{0} is not based on RHEL".format(image)
+        msg = "{0} is not based on RHEL".format(image[:8])
         self.output.list_of_outputs.append(
             self.output.output(iid=image, cid=None,
                                os=None, sevs=None,


### PR DESCRIPTION
image-scanner -i now accepts various inputs as input:

```
- image id
- image name
- image name:tag
- container id
- contaier name
```

The allcontainers and onlyactive command line switches were
also changes to scan the containers rather than only the
images associated with the container.

The summary outputs were also changed to reflect this.  Now
if you scan a container, the Image: label is changed to
Container: and we removed the Containers effected label.

This patch resolves:
     issue #1 https://github.com/baude/image-scanner/issues/1
