### PR TITLE
reporter.py Dump docker-state to json

### DIFF
--- a/reporter.py
+++ b/reporter.py
@@ -21,6 +21,7 @@ import collections
 import os
 from applicationconfiguration import ApplicationConfiguration
 import urlparse
+import json
 
 
 class Reporter(object):
@@ -31,10 +32,14 @@ class Reporter(object):
         self.list_of_outputs = []
         self.appc = ApplicationConfiguration()
         self.report_dir = os.path.join(self.appc.reportdir, "openscap_reports")
+        self.docker_state = os.path.join(self.report_dir, "docker_state.json")
 
         if not os.path.exists(self.report_dir):
             os.mkdir(self.report_dir)
         self.content = ""
+
+        with open(self.docker_state, 'w') as state_file:
+            json.dump(self.appc.fcons, state_file)
 
     def add_content(self, content):
         self.content = self.content + content


### PR DESCRIPTION
When the reporter is run, we now document the "state" of
the containers and images such that if we post-process
XML CVE data, we can advise which containers are impacted
by the findings.  This will be useful for other products
leveraging the image-scanner as middleware.
