### PR TITLE
Error Handling for REST and client API

### DIFF
--- a/image_scanner/applicationconfiguration.py
+++ b/image_scanner/applicationconfiguration.py
@@ -20,6 +20,7 @@
 
 import docker
 import sys
+from image_scanner_client.image_scanner_client import ImageScannerClientError
 
 
 class Singleton(object):
@@ -65,16 +66,20 @@ class ApplicationConfiguration(Singleton):
         self.parserargs = parserargs
 
     def ValidateHost(self, host):
-
+        ''' Validates if the defined docker host is running'''
         try:
             client = docker.Client(base_url=host, timeout=10)
             if not client.ping():
                 raise(Exception)
         except Exception, err:
-            print 'Cannot connect to the Docker daemon. ' \
-                  'Is \'docker -d\' running on this host?'
-            sys.exit(1)
-
+            error = "Cannot connect to the Docker daemon. Is it running on " \
+                    "this host"
+            client = None
+            if not self.api:
+                print error
+                sys.exit(1)
+            else:
+                raise ImageScannerClientError
         return client
 
     def _print(self, msg):

--- a/image_scanner/docker_scanner.py
+++ b/image_scanner/docker_scanner.py
@@ -31,6 +31,7 @@ from image_scanner.applicationconfiguration import ApplicationConfiguration
 from image_scanner.reporter import Reporter
 from image_scanner.scan import Scan
 from image_scanner.docker_mount import DockerMount, DockerMountError
+from image_scanner_client.image_scanner_client import ImageScannerClientError
 import subprocess
 import psutil
 from datetime import datetime
@@ -53,7 +54,6 @@ class Singleton(object):
     def _singleton_init(self, *args, **kwargs):
         """Initialize a singleton instance before it is registered."""
         pass
-
 
 class ContainerSearch(object):
 
@@ -319,9 +319,13 @@ class Worker(object):
                 iid, dtype = dm.get_iid(image)
                 work_list.append(iid)
         except DockerMountError:
-            print "Unable to associate {0} with any image " \
-                  "or container".format(image)
-            sys.exit(1)
+            error = "Unable to associate {0} with any image " \
+                    "or container".format(image)
+            if not self.ac.api:
+                print error
+                sys.exit(1)
+            else:
+                raise ImageScannerClientError(error)
         return work_list
 
     def start_application(self):


### PR DESCRIPTION
```
* Clean up of several areas where we threw a sys.exit(1) which
  broke the client API usage. i.e. the sys.exit would cause the
  rest server to stop.  Now raise an Exception that is caught
  and returns an Error in json format.
```
