### PR TITLE
Fix scan remote xlmp input

### DIFF
--- a/image_scanner_client/image-scanner-remote.py
+++ b/image_scanner_client/image-scanner-remote.py
@@ -17,8 +17,11 @@
 # Boston, MA 02111-1307, USA.
 
 ''' Image Scanner remote client for command line '''
-from image_scanner_client.image_scanner_client import Client, ImageScannerClientError, ClientCommon
-from image_scanner_client.xml_parse import ParseOvalXML
+# from image_scanner_client.image_scanner_client import Client, ImageScannerClientError, ClientCommon
+# from image_scanner_client.xml_parse import ParseOvalXML
+
+from image_scanner_client import Client, ImageScannerClientError, ClientCommon
+from xml_parse import ParseOvalXML
 import sys
 import argparse
 import os
@@ -96,7 +99,8 @@ class RemoteScanner(object):
 
     def print_results(self, json_url):
         ''' Pretty print call to dump results'''
-        self.xmlp.pprint(json_url)
+        docker_state = self.xmlp._get_docker_state(json_url)
+        self.xmlp.pprint(docker_state)
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Scan Utility for Containers')

--- a/image_scanner_client/image-scanner-remote.py
+++ b/image_scanner_client/image-scanner-remote.py
@@ -17,11 +17,8 @@
 # Boston, MA 02111-1307, USA.
 
 ''' Image Scanner remote client for command line '''
-# from image_scanner_client.image_scanner_client import Client, ImageScannerClientError, ClientCommon
-# from image_scanner_client.xml_parse import ParseOvalXML
-
-from image_scanner_client import Client, ImageScannerClientError, ClientCommon
-from xml_parse import ParseOvalXML
+from image_scanner_client.image_scanner_client import Client, ImageScannerClientError, ClientCommon
+from image_scanner_client.xml_parse import ParseOvalXML
 import sys
 import argparse
 import os

--- a/image_scanner_client/sample_api.py
+++ b/image_scanner_client/sample_api.py
@@ -33,7 +33,8 @@ xmlp = ParseOvalXML()
 image_scanner = Client("localhost", "5001", "4")
 
 # Scan an image or container
-scan_results = image_scanner.scan_list(['bef54'])
+# scan_results = image_scanner.scan_list(['bef54'])
+scan_results = image_scanner.scan_list(['c0bb'])
 
 # The result of scan_list will return a JSON based structure
 # that has a very basic summary of the scan as well as
@@ -47,7 +48,7 @@ if debug:
 # resulting docker_state.json file from scan_results which is
 # also a JSON structure.
 
-docker_state = xmlp.get_docker_json(scan_results['json_url'])
+docker_state = image_scanner.get_docker_json(scan_results['json_url'])
 
 if debug:
     debug_print(docker_state)

--- a/image_scanner_client/sample_api.py
+++ b/image_scanner_client/sample_api.py
@@ -33,8 +33,7 @@ xmlp = ParseOvalXML()
 image_scanner = Client("localhost", "5001", "4")
 
 # Scan an image or container
-# scan_results = image_scanner.scan_list(['bef54'])
-scan_results = image_scanner.scan_list(['c0bb'])
+scan_results = image_scanner.scan_list(['bef54'])
 
 # The result of scan_list will return a JSON based structure
 # that has a very basic summary of the scan as well as

--- a/image_scanner_client/sample_api.py
+++ b/image_scanner_client/sample_api.py
@@ -47,7 +47,7 @@ if debug:
 # resulting docker_state.json file from scan_results which is
 # also a JSON structure.
 
-docker_state = image_scanner.get_docker_json(scan_results['json_url'])
+docker_state = xmlp.get_docker_json(scan_results['json_url'])
 
 if debug:
     debug_print(docker_state)


### PR DESCRIPTION
I standardized the input into the main xmlp methods (return_rpm_by_docker_obj, return_cve_by_docker_obj, and pprint).  After doing some tests I added and pushed these commits, but my tiredness got the best of me and I committed debugging code twice.... so I fixed them, tested, and recommitted.  Everything is perfect now - sorry for the confusion  
