### PR TITLE
Drop IPC host communication requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The image-scanner configuration file is located at /etc/image-scanner/image-scan
 Now you can run the image-scanner simply with the atomic command:
 ````
 [bbaude@localhost image-scanner]$ atomic run fedora-image-scannerdocker
-run -dt --privileged -v /proc/:/hostproc/ -v /sys/fs/cgroup:/sys/fs/cgroup -v /var/log:/var/log -v /tmp:/tmp -v /run:/run -v /var/lib/docker/devicemapper/metadata/:/var/lib/docker/devicemapper/metadata/ -v /dev/:/dev/ -v /etc/image-scanner/:/etc/image-scanner --env container=docker --net=host --cap-add=SYS_ADMIN --ipc=host fedora-image-scanner
+run -dt --privileged -v /proc/:/hostproc/ -v /sys/fs/cgroup:/sys/fs/cgroup -v /var/log:/var/log -v /tmp:/tmp -v /run:/run -v /var/lib/docker/devicemapper/metadata/:/var/lib/docker/devicemapper/metadata/ -v /dev/:/dev/ -v /etc/image-scanner/:/etc/image-scanner --env container=docker --net=host --cap-add=SYS_ADMIN fedora-image-scanner
 acb44b0cb87cbcb94047a0c8e8873dcb451ebb927005afce2e8a77929cacdac2
 ````
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ LABEL Vendor="Red Hat" License=GPLv3
 
 LABEL INSTALL="docker run --rm -it --privileged -v /etc/:/host/etc/ -e IMAGE=IMAGE -e NAME=NAME IMAGE sh /root/image-scanner/docker/image-scanner-install.sh"
 
-LABEL RUN="docker run -dt --privileged -v /proc/:/hostproc/ -v /sys/fs/cgroup:/sys/fs/cgroup  -v /var/log:/var/log -v /var/tmp/image-scanner:/var/tmp/image-scanner -v /run:/run -v /var/lib/docker/devicemapper/metadata/:/var/lib/docker/devicemapper/metadata/ -v /dev/:/dev/ -v /etc/image-scanner/:/etc/image-scanner --env container=docker --net=host --cap-add=SYS_ADMIN --ipc=host IMAGE"
+LABEL RUN="docker run -dt --privileged -v /proc/:/hostproc/ -v /sys/fs/cgroup:/sys/fs/cgroup  -v /var/log:/var/log -v /var/tmp/image-scanner:/var/tmp/image-scanner -v /run:/run -v /var/lib/docker/devicemapper/metadata/:/var/lib/docker/devicemapper/metadata/ -v /dev/:/dev/ -v /etc/image-scanner/:/etc/image-scanner --env container=docker --net=host --cap-add=SYS_ADMIN IMAGE"
 
 RUN echo 'PS1="[image-scanner]#  "' > /etc/profile.d/ps1.sh
 

--- a/docker/Dockerfile.fedora
+++ b/docker/Dockerfile.fedora
@@ -8,7 +8,7 @@ LABEL Vendor="Red Hat" License=GPLv3
 
 LABEL INSTALL="docker run --rm -it --privileged -v /etc/:/host/etc/ -e IMAGE=IMAGE -e NAME=NAME IMAGE sh /root/image-scanner/docker/image-scanner-install.sh"
 
-LABEL RUN="docker run -dt --privileged -v /proc/:/hostproc/ -v /sys/fs/cgroup:/sys/fs/cgroup  -v /var/log:/var/log -v /tmp:/tmp -v /run:/run -v /var/lib/docker/devicemapper/metadata/:/var/lib/docker/devicemapper/metadata/ -v /dev/:/dev/ -v /etc/image-scanner/:/etc/image-scanner --env container=docker --net=host --cap-add=SYS_ADMIN --ipc=host IMAGE"
+LABEL RUN="docker run -dt --privileged -v /proc/:/hostproc/ -v /sys/fs/cgroup:/sys/fs/cgroup  -v /var/log:/var/log -v /tmp:/tmp -v /run:/run -v /var/lib/docker/devicemapper/metadata/:/var/lib/docker/devicemapper/metadata/ -v /dev/:/dev/ -v /etc/image-scanner/:/etc/image-scanner --env container=docker --net=host --cap-add=SYS_ADMIN IMAGE"
 
 RUN echo 'PS1="[image-scanner]#  "' > /etc/profile.d/ps1.sh
 


### PR DESCRIPTION
This patch drops the udev sync on dmsetup commands which required IPC communication with the host.
